### PR TITLE
update contributing doc [skip ci]

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing
 
-* Create github issues so that they can be linked to corresponding Pull Requests.
+* Please read the [Code of Conduct](/.github/CODE_OF_CONDUCT.md) before contributing to this project.
+* Please create github issues so that they can be linked to corresponding Pull Requests, especially for larger changes.
+* All code changes should have a new/edited test!
+
+We do not intend to deviate from the [GraphQL Specification](https://graphql.github.io/graphql-spec/) in regards to the grammar or its structure. However, small differences in approach can be left for interpretation as long as the end goal is the same.
 
 ## Formatting
 Please import and use either the provided [Eclipse Java style guide](./documents/style-guide-eclipse.xml) or


### PR DESCRIPTION
# What Changed
More detailed contributing guide in regards to creating github issues and our stance on the graphql specification.
